### PR TITLE
Build draco with TRANSCODER_SUPPORTED to include draco_transcoder binary

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ cmake -G "NMake Makefiles" ^
       -DCMAKE_LIBRARY_PATH="%LIBRARY_LIB%" ^
       -DCMAKE_INCLUDE_PATH="%INCLUDE_INC%" ^
       -DBUILD_SHARED_LIBS=OFF ^
+      -DDRACO_TRANSCODER_SUPPORTED=ON ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,7 @@ cmake ${CMAKE_ARGS} -G "Unix Makefiles" \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=ON \
       -DDRACO_TESTS=OFF \
+      -DDRACO_TRANSCODER_SUPPORTED=ON \
       ..
 
 # CircleCI offers two cores.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/google/draco/archive/{{ version }}.tar.gz
-  sha256: bf6b105b79223eab2b86795363dfe5e5356050006a96521477973aba8f036fe1
+  git_url: https://github.com/google/draco.git  
+  git_rev: {{ version }}
   patches:
     - start-group.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - start-group.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #23 
<!--
Please add any other relevant info below:
-->

In order to build draco with `TRANSCODER_SUPPORTED=ON` it requires the needed third_party libs to be in place. These are referenced as submodules in `draco/third_party`. In order for these to be automatically pulled I had to switch from referencing the tarball archive to actually pulling the git tag from the repo. Hope that is okay.
